### PR TITLE
Bug found when compiling for Javascript

### DIFF
--- a/SpineSprite.cpp
+++ b/SpineSprite.cpp
@@ -35,7 +35,7 @@ void SpineSprite::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bind_slot_nodes"), &SpineSprite::get_bind_slot_nodes);
 	ClassDB::bind_method(D_METHOD("set_bind_slot_nodes", "v"), &SpineSprite::set_bind_slot_nodes);
 	ClassDB::bind_method(D_METHOD("get_overlap"), &SpineSprite::get_overlap);
-	ClassDB::bind_method(D_METHOD("set_overlap", "v"), &SpineSprite::set_overlap);	
+	ClassDB::bind_method(D_METHOD("set_overlap", "v"), &SpineSprite::set_overlap);
 	ClassDB::bind_method(D_METHOD("set_skin", "v"), &SpineSprite::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skin"), &SpineSprite::get_skin);
 	ClassDB::bind_method(D_METHOD("_on_skin_property_changed"), &SpineSprite::_on_skin_property_changed);
@@ -291,8 +291,8 @@ void SpineSprite::gen_mesh_from_skeleton(Ref<SpineSkeleton> s) {
 				break;
 			default:
 				blend_mode = CanvasItemMaterial::BLEND_MODE_MIX;
-		}		
-		mat->set_blend_mode(blend_mode);		
+		}
+		mat->set_blend_mode(blend_mode);
 		mesh_ins->set_material(mat);
 	}
 }
@@ -425,7 +425,7 @@ void SpineSprite::update_mesh_from_skeleton(Ref<SpineSkeleton> s) {
 		}
 
 		auto mesh_ins = mesh_instances[i];
-		VisualServer::get_singleton()->canvas_item_clear(mesh_ins->get_canvas_item());	
+		VisualServer::get_singleton()->canvas_item_clear(mesh_ins->get_canvas_item());
 
 		if (skeleton_clipper->isClipping()) {
 			skeleton_clipper->clipTriangles(vertices, indices, uvs, VERTEX_STRIDE);
@@ -518,7 +518,7 @@ void SpineSprite::update_mesh_from_skeleton(Ref<SpineSkeleton> s) {
 					break;
 				default:
 					blend_mode = CanvasItemMaterial::BLEND_MODE_MIX;
-			}		
+			}
 			mat->set_blend_mode(blend_mode);
 		}
 	}
@@ -792,6 +792,7 @@ void SpineSprite::_get_property_list(List<PropertyInfo> *p_list) const {
     p_list->push_back(PropertyInfo(Variant::INT, "track_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 
     for (size_t i=0; i<current_animations.size(); ++i) {
+
         String prefix = vformat("ca/%d/", i);
         p_list->push_back(PropertyInfo(Variant::NIL, vformat("ID %d", i), PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_GROUP));
         p_list->push_back(PropertyInfo(Variant::INT, vformat("%strack_id", prefix), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));


### PR DESCRIPTION
**How to replicate:**
Run either `scons -j4 platform=javascript tools=no target=release` or `scons -j4 platform=javascript tools=no target=release_debug` in the console to build the export templates for Javascript.

The following errors will be returned:

> scons: Reading SConscript files ...
> Couldn't parse CXX environment variable to infer compiler version.
> WebM SIMD optimizations are disabled. Check if your CPU architecture, CPU bits or platform are supported!
> Checking for C header file mntent.h... (cached) yes
> scons: done reading SConscript files.
> scons: Building targets ...
> [ 50%] Compiling ==> modules\spine_runtime\SpineSprite.cpp
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\minisoap.c
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\minissdpc.c
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\miniwget.c
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\upnpcommands.c
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\upnpdev.c
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\upnpreplyparse.c
> modules\spine_runtime\SpineSprite.cpp:77:55: warning: field 'skeleton_clipper' will be initialized after field 'overlap'
>       [-Wreorder-ctor]
>                 select_track_id(0), empty_animation_duration(0.2f), skeleton_clipper(NULL),
>                                                                     ^~~~~~~~~~~~~~~~~~~~~~
>                                                                     overlap(false)
> modules\spine_runtime\SpineSprite.cpp:341:30: warning: unused variable 'UV_STRIDE' [-Wunused-variable]
>         static const unsigned short UV_STRIDE = 2;
>                                     ^
> [ 53%] **error**: conversion from 'size_t' (aka 'unsigned long') to 'const Variant'
>       is ambiguous
>         String prefix = vformat("ca/%d/", i);
> [ 53%]                                    ^
> .\core/variant.h:254:Compiling ==> thirdparty\miniupnpc\miniupnpc\connecthostport.c
> 2: note: candidate constructor
>         Variant(bool p_bool);
>         ^
> .\core/variant.h:255:2: note: candidate constructor
>         Variant(signed int p_int); // real one
>         ^
> .\core/variant.h:256:2: note: candidate constructor
>         Variant(unsigned int p_int);
>         ^
> .\core/variant.h:262:2: note: candidate constructor
>         Variant(signed short p_short); // real one
>         ^
> .\core/variant.h:263:2: note: candidate constructor
>         Variant(unsigned short p_short);
>         ^
> .\core/variant.h:264:2: note: candidate constructor
>         Variant(signed char p_char); // real one
>         ^
> .\core/variant.h:265:2: note: candidate constructor
>         Variant(unsigned char p_char);
>         ^
> .\core/variant.h:266:2: note: candidate constructor
>         Variant(int64_t p_int); // real one
>         ^
> .\core/variant.h:267:2: note: candidate constructor
>         Variant(uint64_t p_int);
>         ^
> [ 53%] candidate constructor:
>         Variant(float p_float);
>         ^
> [ 53%] .\core/variant.h:269:2: Compiling ==> thirdparty\miniupnpc\miniupnpc\portlistingparse.c
> note: candidate constructor
>         Variant(double p_double);
>         ^
> modules\spine_runtime\SpineSprite.cpp:797:71: **error**: conversion from 'size_t' (aka 'unsigned long') to 'const Variant'
>       is ambiguous
>         p_list->push_back(PropertyInfo(Variant::NIL, vformat("ID %d", i), PROPERTY_HINT_NONE, prefix, PROPERTY_U...
>                                                                       ^
> .\core/variant.h:254:2: note: candidate constructor
>         Variant(bool p_bool);
>         ^
> .\core/variant.h:255:2: note: candidate constructor
>         Variant(signed int p_int); // real one
>         ^
> .\core/variant.h:256:2: note: candidate constructor
>         Variant(unsigned int p_int);
>         ^
> .\core/variant.h:262:2: note: candidate constructor
>         Variant(signed short p_short); // real one
>         ^
> .\core/variant.h:263:2: note: candidate constructor
>         Variant(unsigned short p_short);
> [ 53%]  ^
> [ 53%] : note: candidate constructorCompiling ==> thirdparty\miniupnpc\miniupnpc\receivedata.c
> 
>         Variant(signed char p_char); // real one
>         ^
> .\core/variant.h:265:2: note: candidate constructor
>         Variant(unsigned char p_char);
>         ^
> .\core/variant.h:266:2: note: candidate constructor
>         Variant(int64_t p_int); // real one
>         ^
> .\core/variant.h:267:2: note: candidate constructor
>         Variant(uint64_t p_int);
>         ^
> .\core/variant.h:268:2: note: candidate constructor
>         Variant(float p_float);
>         ^
> .\core/variant.h:269:2: note: candidate constructor
>         Variant(double p_double);
>         ^
> modules\spine_runtime\SpineSprite.cpp:984:88: **error**: conversion from 'size_t' (aka 'unsigned long') to 'const Variant'
>       is ambiguous
>                     print_line(vformat("track_id at 'ID %d'  can not be less than 0!", i));
>                                                                                        ^
> .\core/variant.h:254:2: note: candidate constructor
>         Variant(bool p_bool);
>         ^
> .\core/variant.h:255:2: note: candidate constructor
>         Variant(signed int p_int); // real one
>         ^
> .\core/variant.h:256:2: note: candidate constructor
>         Variant(unsigned int p_int);
>         ^
> .\core/variant.h:262:2: note: candidate constructor
>         Variant(signed short p_short); // real one
>         ^
> .\core/variant.h:263:2: note: candidate constructor
>         Variant(unsigned short p_short);
>         ^
> .\core/variant.h:264:2: note: candidate constructor
>         Variant(signed char p_char); // real one
>         ^
> .\core/variant.h:265:2: note: candidate constructor
>         Variant(unsigned char p_char);
>         ^
> .\core/variant.h:266:2: note: candidate constructor
>         Variant(int64_t p_int); // real one
>         ^
> .\core/variant.h:267:2: note: candidate constructor
>         Variant(uint64_t p_int);
>         ^
> .\core/variant.h:268:2: note: candidate constructor
>         Variant(float p_float);
>         ^
> .\core/variant.h:269:2: note: candidate constructor
>         Variant(double p_double);
>         ^
> [ 53%] Compiling ==> thirdparty\miniupnpc\miniupnpc\addr_is_reserved.c
> 2 warnings and 3 errors generated.
> em++: error: 'D:/emsdk/upstream/bin\clang++.exe -target wasm32-unknown-emscripten -DEMSCRIPTEN -fignore-exceptions -fno-inline-functions -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -D__EMSCRIPTEN_major__=3 -D__EMSCRIPTEN_minor__=1 -D__EMSCRIPTEN_tiny__=0 -D_LIBCPP_ABI_VERSION=2 -Werror=implicit-function-declaration -Xclang -iwithsysroot/include/SDL --sysroot=D:\emsdk\upstream\emscripten\cache\sysroot -Xclang -iwithsysroot/include\compat -c -std=gnu++14 -Os -fno-exceptions -fno-rtti -Wall -Wno-ordered-compare-function-pointers -Werror=return-type -O2 -DNO_EDITOR_SPLASH -DNO_SAFE_CAST -DJAVASCRIPT_ENABLED -DUNIX_ENABLED -DJAVASCRIPT_EVAL_ENABLED -DNO_THREADS -DNDEBUG -DPTRCALL_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -Ithirdparty\freetype\include -Ithirdparty\libpng -Ithirdparty\zstd -Ithirdparty\zlib -Iplatform\javascript -I. -Imodules\spine_runtime\spine-cpp\include modules\spine_runtime\SpineSprite.cpp -o modules\spine_runtime\SpineSprite.javascript.opt.bc' failed (returned 1)
> [ 53%] Compiling ==> thirdparty\vhacd\src\vhacdManifoldMesh.cpp
> [ 53%] Compiling ==> thirdparty\vhacd\src\FloatMath.cpp
> scons: *** [modules\spine_runtime\SpineSprite.javascript.opt.bc] Error 1
> scons: building terminated because of errors.
> [Time elapsed: 00:00:36.006]